### PR TITLE
Refine README installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
   <img src="./assets/readme/readme-title.svg" width="100%" alt="oil-ppt：用最简单的方式，做出最好看的 PPT。">
 </p>
 
-```bash
-npx skills add oil-oil/oil-ppt
-```
-
 <p align="center">
   <img src="./assets/readme/readme-section-showcase.svg" width="100%" alt="01 先看效果">
 </p>
@@ -20,26 +16,18 @@ npx skills add oil-oil/oil-ppt
     <td width="50%"><img src="./assets/readme/showcase-jwst-cobalt.png" alt="詹姆斯·韦布空间望远镜演示，钴蓝主题"></td>
   </tr>
   <tr>
-    <td align="center"><sub>oil-ppt 产品理念 · 黄色</sub></td>
-    <td align="center"><sub>詹姆斯·韦布空间望远镜 · 钴蓝</sub></td>
-  </tr>
-  <tr>
     <td width="50%"><img src="./assets/readme/showcase-highline-moss.png" alt="纽约高线公园演示，苔绿色主题"></td>
     <td width="50%"><img src="./assets/readme/showcase-bauhaus-clay.png" alt="包豪斯设计方法演示，陶土色主题"></td>
   </tr>
-  <tr>
-    <td align="center"><sub>纽约高线公园 · 苔绿</sub></td>
-    <td align="center"><sub>包豪斯设计方法 · 陶土色</sub></td>
-  </tr>
 </table>
-
-这些页面来自四套真实演示。它们使用同一套设计系统，但配色、素材、密度和页面结构会跟着内容改变。
 
 <p align="center">
   <img src="./assets/readme/readme-section-system.svg" width="100%" alt="02 oil-ppt 是什么">
 </p>
 
 oil-ppt 是一个给 Agent 使用的 PPT Skill。我们可以给它一个主题、一份文档或一组材料，它会先确认这套演示要讲什么，再生成可以全屏播放、离线打开的 16:9 HTML 演示文稿。
+
+上面的十五张页面来自四套真实演示，分别使用黄色、钴蓝、苔绿和陶土色。它们共享同一套设计系统，但素材、密度和页面结构会跟着内容改变。
 
 它不让模型同时承担内容、排版、图片适配和浏览器检查。模型负责理解与选择，oil-ppt 负责稳定执行，我们负责两次关键确认。最后只交付一个 `演示文稿.html`。
 
@@ -90,7 +78,21 @@ oil-ppt 把每次修改限制在当前页面，让每页可以单独生成、检
   <img src="./assets/readme/readme-section-start.svg" width="100%" alt="06 怎么使用">
 </p>
 
-产品与仓库名是 `oil-ppt`，当前兼容调用名仍是 `oil-slides`：
+**方式一 · 执行命令**
+
+```bash
+npx skills add oil-oil/oil-ppt
+```
+
+**方式二 · 直接交给 Agent**
+
+把下面这句话发给 Agent，让它完成安装：
+
+```text
+请安装这个 Skill：https://github.com/oil-oil/oil-ppt
+```
+
+安装完成后，当前兼容调用名仍是 `oil-slides`：
 
 ```text
 [$oil-slides] 帮我做一份关于这个主题的演示文稿。

--- a/assets/readme/readme-section-start.svg
+++ b/assets/readme/readme-section-start.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="138" viewBox="0 0 1200 138" role="img" aria-label="06 怎么使用">
   <defs><pattern id="g" width="34" height="34" patternUnits="userSpaceOnUse"><path d="M34 0H0V34" fill="none" stroke="#202220" stroke-opacity=".05"/></pattern><pattern id="d" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="2" cy="2" r="1.8" fill="#202220" fill-opacity=".12"/></pattern></defs>
   <rect width="1200" height="138" rx="20" fill="#f8f8f5"/><rect width="1200" height="138" rx="20" fill="url(#g)"/>
-  <text x="54" y="34" fill="#7b7f7b" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI','PingFang SC',sans-serif" font-size="16" font-weight="700" letter-spacing="2.8">GET STARTED · ONE COMMAND</text><rect x="54" y="49" width="50" height="5" rx="3" fill="#efc84a"/>
+  <text x="54" y="34" fill="#7b7f7b" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI','PingFang SC',sans-serif" font-size="16" font-weight="700" letter-spacing="2.8">GET STARTED · TWO WAYS TO INSTALL</text><rect x="54" y="49" width="50" height="5" rx="3" fill="#efc84a"/>
   <text x="54" y="105" fill="#202220" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI','PingFang SC',sans-serif" font-size="42" font-weight="750">怎么使用</text><rect x="880" y="22" width="180" height="96" fill="url(#d)"/><circle cx="1057" cy="103" r="6" fill="#efc84a"/><text x="1090" y="102" fill="#202220" fill-opacity=".14" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="72" font-weight="800">06</text>
 </svg>


### PR DESCRIPTION
## 更新内容

- 移除品牌标题与作品展示之间的安装命令
- 将安装方式统一移动到「怎么使用」章节
- 增加两种安装方式：执行 `npx` 命令，或把仓库链接直接交给 Agent
- 移除四张作品图之间的标题与配色说明，让展示区保持纯视觉
- 将四套主题与配色的说明移动到「oil-ppt 是什么」
- 将章节英文说明更新为 `TWO WAYS TO INSTALL`

## 检查

- README 本地渲染通过
- 所有图片正常加载
- SVG XML 校验通过
- Git diff whitespace 检查通过
