### PR TITLE
Replace the README credit with a native SVG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ oil-slides/scripts/oil-slides doctor
 </details>
 
 <p align="center">
-  <sub>这份 README 使用 <a href="https://github.com/oil-oil/beautify-github-readme"><code>beautify-github-readme</code></a> 完成内容整理和视觉设计。</sub>
+  <a href="https://github.com/oil-oil/beautify-github-readme"><img src="./assets/readme/made-with-beautify.svg" width="300" alt="README made with beautify-github-readme"></a>
 </p>
 
 <p align="center"><sub>MIT License</sub></p>

--- a/assets/readme/made-with-beautify.svg
+++ b/assets/readme/made-with-beautify.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="64" viewBox="0 0 420 64" role="img" aria-labelledby="title desc">
+  <title id="title">README made with beautify-github-readme</title>
+  <desc id="desc">A compact oil-ppt styled credit linking to beautify-github-readme.</desc>
+  <rect x=".5" y=".5" width="419" height="63" rx="14" fill="#F8F8F5" stroke="#DEDED8"/>
+  <path d="M16 0V64M32 0V64" stroke="#202220" stroke-opacity=".045"/>
+  <circle cx="28" cy="32" r="10" fill="#202220"/>
+  <circle cx="28" cy="32" r="3" fill="#EFC84A"/>
+  <text x="52" y="25" fill="#878B87" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="10" font-weight="700" letter-spacing="1.7">README MADE WITH</text>
+  <rect x="52" y="34" width="180" height="14" rx="2" fill="#F6DF88" fill-opacity=".72"/>
+  <text x="52" y="47" fill="#202220" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="15" font-weight="750">beautify-github-readme</text>
+  <circle cx="389" cy="32" r="14" fill="#FFFFFF" stroke="#DEDED8"/>
+  <path d="M384 37l10-10M387 27h7v7" fill="none" stroke="#202220" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## 做了什么

用一张 oil-ppt 风格的小型 SVG 替换 README 末尾的纯文字署名。签名牌沿用细网格、黄色强调和克制的浅色容器，并继续链接到 `beautify-github-readme`。

## 影响

仅修改 README 与新增一张 SVG，不影响 Skill 或演示构建。

## 验证

- `xmllint --noout assets/readme/made-with-beautify.svg`
- 本地渲染检查 300px 嵌入尺寸
- `git diff --check`
