### PR TITLE
harden oil-ppt workflow contract

### DIFF
--- a/oil-ppt/SKILL.md
+++ b/oil-ppt/SKILL.md
@@ -33,13 +33,22 @@ scripts/oil-ppt batch <项目或父目录> [更多项目或父目录]
 scripts/oil-ppt status <项目> --json
 ```
 
-之后形成一个循环：执行 `next.command` 或编辑 `next.path`，再重新运行 `status --json`。只解释以下动作，不另外拼接流程：
+之后形成一个循环：执行程序返回的完整命令或编辑 `next.path`，再重新运行 `status --json`。顶层帮助会故意隐藏部分仍可调用的内部工作流命令；只能原样执行 `status` / `batch` 返回的绝对命令，不能根据命令名、帮助或记忆手拼。`next.action` 是以下封闭集合，出现集合外的值必须视为程序错误并停止：
 
-- `run_command`：直接执行 `next.command`；它已是可从任意目录运行的绝对命令。
-- `edit_outline` / `write_visual_plan` / `fix_media`：只处理 `next.path` 和 `next.issues`，完成后重新运行 `status`。
-- `ask_user_to_confirm_*`：展示 `next.artifact` 并停止；只有用户明确确认后才执行 `next.command_on_confirm`。
+<!-- next-action-contract:start -->
+- `ask_user_to_confirm_outline`：展示 `next.artifact` 并停止；只有用户明确确认后才原样执行 `next.command_on_confirm`。
+- `ask_user_to_confirm_preview`：展示 `next.artifact` 并停止；只有用户明确确认后才原样执行 `next.command_on_confirm`。
+- `ask_user_to_confirm_previews`：展示 `next.artifacts` 并停止；只有用户明确确认全部预览后才原样执行 `next.command_on_confirm`。
+- `ask_user_to_confirm_text_only`：展示 `next.artifact` 并停止；只有用户明确要求整套无图片后才原样执行 `next.command_on_confirm`。
+- `choose_project_directory`：停止并请用户选择项目目录，不猜测或创建路径。
+- `complete`：停止，流程已完成。
+- `edit_outline`：只编辑 `next.path`，完成后重新运行 `status`。
+- `fix_media`：如果 `next.reference_command` 存在，先原样执行它以生成槽位与比例计划；然后只处理 `next.path` 和 `next.issues`，完成后原样执行 `next.rerun`。该参考命令不会自动生成或获取任意外部素材。
+- `run_command`：原样执行 `next.command`；它已是可从任意目录运行的绝对命令。
 - `start_editor`：启动 `next.command` 后立即把页面交给用户，不等待这个本地服务退出；用户点击“完成编辑”后重新运行 `status`。
-- `wait_for_editor` / `complete` / `choose_project_directory`：停止，不猜测下一命令。
+- `wait_for_editor`：停止，等待用户完成或关闭当前编辑器。
+- `write_visual_plan`：只编辑 `next.path`；可先原样执行 `next.reference_command` 查看合法参考，完成后重新运行 `status`。
+<!-- next-action-contract:end -->
 
 需要重新打开已完成演示的文字编辑器时，不重走构建流程：
 
@@ -84,7 +93,7 @@ scripts/oil-ppt contract --id <组件>
 
 一页只表达一个主要判断。内容少时选择聚焦组件，不用小字、空卡片或装饰填满空间；有真实证据时优先使用截图、材料或照片。标题中确有需要记住的短语时最多设置一处 `highlight`。
 
-`status` 返回 `fix_media` 时，一次处理完 `next.issues`；`next.reference_command` 会生成槽位与比例计划。真实截图使用程序化适配，不让图片模型重画。
+`status` 返回 `fix_media` 时严格遵循上面的动作路由：先运行已有的 `next.reference_command`，再依据生成的槽位与比例计划一次处理完 `next.path` / `next.issues`，最后运行 `next.rerun`。程序只负责规划、检查和已提供素材的程序化适配，不会自动生成或获取任意外部素材；真实截图不让图片模型重画。
 
 只有需要获取外部素材时读取 `references/media.md`；生成概念插画时读取 `references/illustration.md`；用代码绘制 UI、流程、关系或图表时读取 `references/programmatic-visuals.md`。
 

--- a/oil-ppt/manifest.json
+++ b/oil-ppt/manifest.json
@@ -2,8 +2,8 @@
   "files": [
     {
       "path": "SKILL.md",
-      "sha256": "8eb5b01b20719a41b653e4ab643134d237915920d7c0c6831c061fee375feb54",
-      "size": 6122
+      "sha256": "2c71fbd990e0625f25bffc3d6981a6d41a5eb68e1f978884f0c43ad58ede465b",
+      "size": 7563
     },
     {
       "path": "agents/openai.yaml",
@@ -387,8 +387,8 @@
     },
     {
       "path": "scripts/oil_ppt.py",
-      "sha256": "2a719433525368be036cae5d63aab2cf078c6f5d61a30271d57e58c187266700",
-      "size": 147766
+      "sha256": "5f2251d19a5fe6b689ffb6ff26c014809b780003874db327c44660b4338b3158",
+      "size": 148415
     },
     {
       "path": "scripts/outline_schema.py",
@@ -437,8 +437,13 @@
     },
     {
       "path": "scripts/validate_skill.py",
-      "sha256": "58fb259c8d098599b3ca5bd4704f6f38456ce826f2cb0e15fbf0b8ffc144903a",
-      "size": 38256
+      "sha256": "33bd55c4d4ad44e15c4be543d122c72ce4eb76d9277c40d4afbe4075b2e41b42",
+      "size": 39426
+    },
+    {
+      "path": "scripts/workflow_contract.py",
+      "sha256": "1b0664e984bc6b0c0477fe4144f25a3c70b2abc16a9a16585fb4fa817e14639e",
+      "size": 2184
     },
     {
       "path": "tests/test_cli_contract.py",
@@ -469,9 +474,14 @@
       "path": "tests/test_version_cli.py",
       "sha256": "85d92e9a88ab157682f2d3bc925a220eb15573014f57832667500c394a38ac3b",
       "size": 943
+    },
+    {
+      "path": "tests/test_workflow_contract.py",
+      "sha256": "76938aa24544fb2553868da106beea8ec0f2cf680a8f8081f42a9ca0a3f7f852",
+      "size": 2915
     }
   ],
   "package_version": "0.3.0",
   "schema_version": "oil-ppt.package/v1",
-  "tree_sha256": "029da4b1fcf11a074fbd89327822f3fa31315a8380a140f45b7f088ca25f98e7"
+  "tree_sha256": "c7fb10393708f9db909f180a46a35bc4130d53e0ab25d37ef402671fbf849e5e"
 }

--- a/oil-ppt/scripts/oil_ppt.py
+++ b/oil-ppt/scripts/oil_ppt.py
@@ -33,6 +33,7 @@ from icon_registry import print_icon_results
 from outline_schema import BASE_VISIBLE_FIELDS, DECK_FIELDS, MAX_ABS_DATA_VALUE, MEDIA_TEMPLATES, SHARED_SLIDE_FIELDS, SLIDE_ALLOWED_FIELDS, TEMPLATE_CONTENT_HELP, TEMPLATE_FAMILIES, TEMPLATE_VISIBLE_FIELDS, VARIANT_INPUT_GUIDANCE, text_budgets_for, validate_outline
 from palette_tokens import PALETTES, TOKEN_KEYS, canonical_name, named_palette, normalize_palette
 from profile_tokens import SHAPE_PROFILES, TYPE_PROFILES
+from workflow_contract import validate_batch_payload, validate_status_payload
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -1875,7 +1876,7 @@ def batch_projects(
         }
     else:
         next_step = {"action": "complete", "command": None}
-    return {
+    return validate_batch_payload({
         "schema_version": "oil-ppt.batch/v1",
         # An actionable human/model gate is a valid batch result, not a CLI
         # failure. Reserve the non-zero exit for a deterministic step that
@@ -1884,7 +1885,7 @@ def batch_projects(
         "summary": summary,
         "projects": results,
         "next": next_step,
-    }
+    })
 
 
 def read_config(project: Path) -> tuple[Path, dict]:
@@ -2274,7 +2275,7 @@ def preview_state_status(outline: Path) -> tuple[str, dict | None, str | None]:
     return "confirmed" if state.get("confirmed") is True else "awaiting-confirmation", state, None
 
 
-def status_payload(project_arg: Path, *, intent: str = "continue") -> dict:
+def _status_payload_unchecked(project_arg: Path, *, intent: str = "continue") -> dict:
     if intent not in {"continue", "edit"}:
         raise ValueError(f"Unsupported status intent: {intent}")
     requested = project_arg.expanduser()
@@ -2536,6 +2537,11 @@ def status_payload(project_arg: Path, *, intent: str = "continue") -> dict:
         "blockers": blockers,
         "next": {"action": next_action, "command": next_command, **next_details},
     }
+
+
+def status_payload(project_arg: Path, *, intent: str = "continue") -> dict:
+    """Return a status envelope only after enforcing its closed next-action contract."""
+    return validate_status_payload(_status_payload_unchecked(project_arg, intent=intent))
 
 
 def print_status(project: Path, *, as_json: bool, intent: str = "continue") -> None:
@@ -2863,7 +2869,10 @@ def parse_args() -> argparse.Namespace:
         description="Create and validate an oil-ppt project through one stateful CLI.",
         epilog=(
             "Existing work: batch TARGET [TARGET ...]. New work: init PROJECT, write outline.md, then repeat "
-            "status PROJECT --json and follow its single next action. Run command_on_confirm only after user approval."
+            "status PROJECT --json and follow its single next action. Run command_on_confirm only after user approval. "
+            "Status may return absolute commands for callable workflow commands intentionally omitted from this "
+            "top-level help. Execute only the exact command string returned by status; never reconstruct or "
+            "hand-write an omitted workflow command."
         ),
     )
     public_commands = ("init", "batch", "status", "contract", "media", "icon", "doctor", "version")

--- a/oil-ppt/scripts/validate_skill.py
+++ b/oil-ppt/scripts/validate_skill.py
@@ -18,6 +18,7 @@ from icon_registry import ICON_CATALOG, verify_icons
 from outline_schema import DECK_FIELDS, SHARED_SLIDE_FIELDS, SLIDE_ALLOWED_FIELDS, TEMPLATE_CONTENT_HELP, TEMPLATE_FAMILIES, TEMPLATE_VISIBLE_FIELDS, VARIANT_INPUT_GUIDANCE
 from palette_tokens import PALETTES
 from media_plan import MEDIA_SLOTS, MEDIA_VARIANT_SLOTS
+from workflow_contract import BATCH_NEXT_ACTIONS
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -128,6 +129,7 @@ def validate_skill() -> None:
         "scripts/oil-ppt",
         "scripts/oil-ppt.cmd",
         "scripts/oil_ppt.py",
+        "scripts/workflow_contract.py",
         "scripts/package_manifest.py",
         "scripts/init_deck.py",
         "scripts/add_slide.py",
@@ -408,6 +410,25 @@ def validate_skill() -> None:
             label = source.relative_to(ROOT) if ROOT in source.parents else source.name
             errors.append(f"{label} still exposes the retired oil-slides public name")
     skill_text = SKILL.read_text(encoding="utf-8")
+    action_contract = re.search(
+        r"<!-- next-action-contract:start -->(.*?)<!-- next-action-contract:end -->",
+        skill_text,
+        re.S,
+    )
+    if action_contract is None:
+        errors.append("SKILL.md must contain the delimited next.action contract")
+    else:
+        documented_actions = set(re.findall(r"^- `([a-z_]+)`：", action_contract.group(1), re.M))
+        if documented_actions != set(BATCH_NEXT_ACTIONS):
+            missing = sorted(set(BATCH_NEXT_ACTIONS) - documented_actions)
+            extra = sorted(documented_actions - set(BATCH_NEXT_ACTIONS))
+            errors.append(f"SKILL.md next.action contract mismatch; missing={missing}, extra={extra}")
+    required_fix_media_text = (
+        "如果 `next.reference_command` 存在，先原样执行它以生成槽位与比例计划；"
+        "然后只处理 `next.path` 和 `next.issues`，完成后原样执行 `next.rerun`"
+    )
+    if required_fix_media_text not in skill_text:
+        errors.append("SKILL.md must route fix_media through reference_command, path/issues, then rerun")
     for reference in sorted((ROOT / "references").glob("*.md")):
         relative = f"references/{reference.name}"
         if relative not in skill_text:

--- a/oil-ppt/scripts/workflow_contract.py
+++ b/oil-ppt/scripts/workflow_contract.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Closed next-action contracts for public status and batch envelopes."""
+from __future__ import annotations
+
+
+STATUS_NEXT_ACTIONS = frozenset({
+    "ask_user_to_confirm_outline",
+    "ask_user_to_confirm_preview",
+    "ask_user_to_confirm_text_only",
+    "choose_project_directory",
+    "complete",
+    "edit_outline",
+    "fix_media",
+    "run_command",
+    "start_editor",
+    "wait_for_editor",
+    "write_visual_plan",
+})
+BATCH_NEXT_ACTIONS = STATUS_NEXT_ACTIONS | {"ask_user_to_confirm_previews"}
+
+
+def validate_next_step(next_step: object, *, allowed_actions: frozenset[str], source: str) -> None:
+    """Fail before exposing a next step outside the program-owned action vocabulary."""
+    if not isinstance(next_step, dict):
+        raise SystemExit(f"{source} contract violation: next must be an object.")
+    action = next_step.get("action")
+    if not isinstance(action, str) or not action:
+        raise SystemExit(f"{source} contract violation: next.action must be a non-empty string.")
+    if action not in allowed_actions:
+        allowed = ", ".join(sorted(allowed_actions))
+        raise SystemExit(
+            f"{source} contract violation: unsupported next.action {action!r}. "
+            f"Allowed actions: {allowed}."
+        )
+
+
+def validate_status_payload(payload: dict) -> dict:
+    validate_next_step(
+        payload.get("next"),
+        allowed_actions=STATUS_NEXT_ACTIONS,
+        source="status",
+    )
+    return payload
+
+
+def validate_batch_payload(payload: dict) -> dict:
+    projects = payload.get("projects")
+    if not isinstance(projects, list):
+        raise SystemExit("batch contract violation: projects must be a list.")
+    for index, project in enumerate(projects):
+        if not isinstance(project, dict):
+            raise SystemExit(f"batch contract violation: projects[{index}] must be an object.")
+        validate_next_step(
+            project.get("next"),
+            allowed_actions=STATUS_NEXT_ACTIONS,
+            source=f"batch.projects[{index}]",
+        )
+    validate_next_step(
+        payload.get("next"),
+        allowed_actions=BATCH_NEXT_ACTIONS,
+        source="batch",
+    )
+    return payload

--- a/oil-ppt/tests/test_workflow_contract.py
+++ b/oil-ppt/tests/test_workflow_contract.py
@@ -1,0 +1,71 @@
+"""Regression tests for model-facing workflow dispatch contracts."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+CLI = SCRIPTS / "oil-ppt"
+sys.path.insert(0, str(SCRIPTS))
+
+from workflow_contract import (  # noqa: E402
+    BATCH_NEXT_ACTIONS,
+    STATUS_NEXT_ACTIONS,
+    validate_batch_payload,
+    validate_status_payload,
+)
+import oil_ppt  # noqa: E402
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_action_vocabulary_is_closed_and_batch_has_one_explicit_extension(self) -> None:
+        self.assertEqual(BATCH_NEXT_ACTIONS - STATUS_NEXT_ACTIONS, {"ask_user_to_confirm_previews"})
+        self.assertIn("fix_media", STATUS_NEXT_ACTIONS)
+        self.assertNotIn("generate_external_media", BATCH_NEXT_ACTIONS)
+
+    def test_status_rejects_an_unknown_next_action(self) -> None:
+        with self.assertRaisesRegex(SystemExit, r"status contract violation: unsupported next\.action 'invent_step'"):
+            validate_status_payload({"next": {"action": "invent_step", "command": None}})
+
+        with mock.patch.object(
+            oil_ppt,
+            "_status_payload_unchecked",
+            return_value={"next": {"action": "invent_step", "command": None}},
+        ):
+            with self.assertRaisesRegex(SystemExit, r"status contract violation: unsupported next\.action 'invent_step'"):
+                oil_ppt.status_payload(Path("unused"))
+
+    def test_batch_rejects_unknown_nested_and_top_level_actions(self) -> None:
+        with self.assertRaisesRegex(SystemExit, r"batch\.projects\[0\].*unsupported next\.action 'invent_step'"):
+            validate_batch_payload({
+                "projects": [{"next": {"action": "invent_step", "command": None}}],
+                "next": {"action": "complete", "command": None},
+            })
+        with self.assertRaisesRegex(SystemExit, r"batch contract violation: unsupported next\.action 'invent_step'"):
+            validate_batch_payload({
+                "projects": [{"next": {"action": "complete", "command": None}}],
+                "next": {"action": "invent_step", "command": None},
+            })
+
+    def test_top_level_help_explains_hidden_callable_workflow_commands(self) -> None:
+        result = subprocess.run(
+            [str(CLI), "--help"],
+            cwd=SKILL_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("callable workflow commands intentionally omitted", result.stdout)
+        self.assertIn("Execute only the exact command string returned by status", result.stdout)
+        self.assertNotIn("{init,batch,status,plan,", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define a closed workflow-state contract for `next.action`
- clarify hidden workflow command help and remediation behavior
- add validator coverage plus focused workflow-contract tests
- refresh the package manifest for the updated skill tree

## Validation

- 29 Python unit tests passed
- skill validator passed
- manifest verification passed
- full oil-ppt doctor/render matrix passed (62 combinations)