### PR TITLE
fix(ci): install PPTX test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install PPTX test dependencies
+        run: python -m pip install --disable-pip-version-check Pillow python-pptx
+
       - name: Verify package manifest
         run: python oil-ppt/scripts/package_manifest.py --verify --json
 


### PR DESCRIPTION
## Summary

- Install Pillow and python-pptx before running the oil-ppt test suite.
- Make the three hybrid PPTX tests runnable in the clean GitHub Actions environment.

## Validation

- Reproduced the original missing-module failures from PR 14 logs.
- Installed the same dependencies in a fresh local virtual environment and passed all 7 PPTX export tests.
- Full local suite passes 88 tests.

Shipped via git-ship